### PR TITLE
Fix cursor focus and update default server URL

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,5 @@
 {
-  "vikunja_url": "https://vikunja.example.com",
+  "vikunja_url": "https://app.vikunja.cloud",
   "api_token": "tk_your_api_token_here",
   "default_project_id": 2,
   "hotkey": "Alt+Shift+V"

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -172,6 +172,13 @@ async function loadConfig() {
 }
 loadConfig();
 
+// Close window when clicking outside the container (transparent area)
+document.addEventListener('mousedown', (e) => {
+  if (!container.contains(e.target)) {
+    window.api.closeWindow();
+  }
+});
+
 // Initial animation on first load
 requestAnimationFrame(() => {
   container.classList.add('visible');

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -13,7 +13,7 @@
 
     <div class="form-group">
       <label for="vikunja-url">Vikunja URL</label>
-      <input id="vikunja-url" type="url" placeholder="https://vikunja.example.com" spellcheck="false" />
+      <input id="vikunja-url" type="url" placeholder="https://app.vikunja.cloud" spellcheck="false" />
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
Close quick entry window when clicking outside the container card (transparent area), preventing the stuck-focus state where input loses focus but the window stays visible. Update default Vikunja URL placeholder to https://app.vikunja.cloud to match README.

https://claude.ai/code/session_01LMqHuzNJkybMiwDuhtB4Z8