### PR TITLE
Derive release artifact names from git tag instead of package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,10 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
 
+      - name: Extract version from tag
+        shell: bash
+        run: echo "BUILD_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
       - name: Build installer
         run: npm run make
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,6 +1,6 @@
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
-const { version } = require('./package.json');
+const version = process.env.BUILD_VERSION || require('./package.json').version;
 
 module.exports = {
   packagerConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikunja-quick-entry",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikunja-quick-entry",
-      "version": "1.3.5",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@electron-forge/cli": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vikunja-quick-entry",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "A lightweight system tray app with a global hotkey for quick task entry to Vikunja",
   "main": "src/main.js",
   "scripts": {


### PR DESCRIPTION
Windows (.exe) and macOS (.dmg) artifact names were using the version from package.json, while Linux used the git tag. This caused mismatched filenames when package.json wasn't bumped before tagging (e.g. v1.4 release had 1.3.5 in exe/dmg names). Now all platforms use BUILD_VERSION from the git tag. Also bumps package.json to 1.4.0.