### PR TITLE
Fix due date lost when completing/undoing tasks in Quick View

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -388,7 +388,7 @@ function fetchTasks(filterParams) {
   });
 }
 
-function markTaskDone(taskId) {
+function markTaskDone(taskId, taskData) {
   const config = getConfig();
   if (!config) {
     return Promise.resolve({ success: false, error: 'Configuration not loaded' });
@@ -401,7 +401,9 @@ function markTaskDone(taskId) {
     return Promise.resolve({ success: false, error: validation.error });
   }
 
-  const body = { done: true };
+  // Include original task data to prevent Vikunja from zeroing fields (Go zero-value problem).
+  // When only { done: true } is sent, fields like due_date and priority get reset to zero values.
+  const body = { ...taskData, done: true };
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => {
@@ -457,7 +459,7 @@ function markTaskDone(taskId) {
   });
 }
 
-function markTaskUndone(taskId) {
+function markTaskUndone(taskId, taskData) {
   const config = getConfig();
   if (!config) {
     return Promise.resolve({ success: false, error: 'Configuration not loaded' });
@@ -470,7 +472,9 @@ function markTaskUndone(taskId) {
     return Promise.resolve({ success: false, error: validation.error });
   }
 
-  const body = { done: false };
+  // Include original task data to restore all fields including due_date.
+  // Sending only { done: false } would leave fields zeroed from the markDone call.
+  const body = { ...taskData, done: false };
 
   return new Promise((resolve) => {
     const timeout = setTimeout(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -615,12 +615,12 @@ ipcMain.handle('fetch-viewer-tasks', async () => {
   return fetchTasks(filterParams);
 });
 
-ipcMain.handle('mark-task-done', async (_event, taskId) => {
-  return markTaskDone(taskId);
+ipcMain.handle('mark-task-done', async (_event, taskId, taskData) => {
+  return markTaskDone(taskId, taskData);
 });
 
-ipcMain.handle('mark-task-undone', async (_event, taskId) => {
-  return markTaskUndone(taskId);
+ipcMain.handle('mark-task-undone', async (_event, taskId, taskData) => {
+  return markTaskUndone(taskId, taskData);
 });
 
 ipcMain.handle('open-task-in-browser', (_event, taskId) => {

--- a/src/viewer-preload.js
+++ b/src/viewer-preload.js
@@ -2,8 +2,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('viewerApi', {
   fetchTasks: () => ipcRenderer.invoke('fetch-viewer-tasks'),
-  markTaskDone: (taskId) => ipcRenderer.invoke('mark-task-done', taskId),
-  markTaskUndone: (taskId) => ipcRenderer.invoke('mark-task-undone', taskId),
+  markTaskDone: (taskId, taskData) => ipcRenderer.invoke('mark-task-done', taskId, taskData),
+  markTaskUndone: (taskId, taskData) => ipcRenderer.invoke('mark-task-undone', taskId, taskData),
   openTaskInBrowser: (taskId) => ipcRenderer.invoke('open-task-in-browser', taskId),
   closeWindow: () => ipcRenderer.invoke('close-viewer'),
   onShowWindow: (callback) => {


### PR DESCRIPTION
Vikunja's API (Go) zeroes omitted fields on POST update. When marking a task done/undone, only { done: true/false } was sent, causing due_date, priority, and other fields to be reset to zero values on the server. The UI cached original data locally but the server had already lost the fields.

Now pass the full original task data through the entire IPC chain (viewer -> preload -> main -> api) so all fields are preserved in both the mark-done and undo API calls.

https://claude.ai/code/session_014DRiDWVgaPM9qUR7Jr21Ys