### PR TITLE
Vikunja uses reverse syntax for urgency levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Type everything in one line and the parser extracts structured fields automatica
 **Priority** — two syntax modes:
 | Todoist mode (default) | Vikunja mode | Meaning |
 |------------------------|--------------|---------|
-| `p1` | `!1` | Urgent |
-| `p2` | `!2` | High |
-| `p3` | `!3` | Medium |
-| `p4` | `!4` | Low |
+| `p1` | `!4` | Urgent |
+| `p2` | `!3` | High |
+| `p3` | `!2` | Medium |
+| `p4` | `!1` | Low |
 
 Both modes also accept `!urgent`, `!high`, `!medium`, `!low`.
 


### PR DESCRIPTION
Current table lists Vikunja priority levels in reverse. 
Only documentation change needed, app functionality is otherwise fine. 

For some reason Vikunja went against the grain and has p1 as low and p4 as urgent... 
